### PR TITLE
Adds `ReactViewCloser` native module

### DIFF
--- a/TestApp.xcodeproj/project.pbxproj
+++ b/TestApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3B89BAC71F66E232A6E680DA /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DB539CB0C2A42AD1C3F8DB8 /* libPods.a */; };
 		4CD515211B8ECEC600C5B802 /* view.js in Resources */ = {isa = PBXBuildFile; fileRef = 4CD515201B8ECEC600C5B802 /* view.js */; };
+		551A71261B8FBC5B0092CE83 /* ReactViewCloser.m in Sources */ = {isa = PBXBuildFile; fileRef = 551A71251B8FBC5B0092CE83 /* ReactViewCloser.m */; };
 		F726F11E79A6D8A42EE99C7E /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F726F60FA45E725B05ED3421 /* main.m */; };
 		F726F1A186540B5C839AC7D5 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F726F43EA3BE86E1948572B9 /* Main.storyboard */; };
 		F726F656F5088F742AA93848 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = F726FC94241A5B73C22C44BA /* LaunchScreen.xib */; };
@@ -32,6 +33,8 @@
 
 /* Begin PBXFileReference section */
 		4CD515201B8ECEC600C5B802 /* view.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = view.js; path = ReactView/view.js; sourceTree = "<group>"; };
+		551A71241B8FBC5B0092CE83 /* ReactViewCloser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReactViewCloser.h; sourceTree = "<group>"; };
+		551A71251B8FBC5B0092CE83 /* ReactViewCloser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReactViewCloser.m; sourceTree = "<group>"; };
 		7623102B6CBE573CFE0F8010 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		7DB539CB0C2A42AD1C3F8DB8 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC9F268C58126EF580AF697C /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
@@ -131,6 +134,8 @@
 				F726F0D163CB86B4F1493686 /* ReactView.h */,
 				F726FE4BA6BE2542FAC6CD25 /* MyReactView.m */,
 				F726F28905899C598642B515 /* MyReactView.h */,
+				551A71241B8FBC5B0092CE83 /* ReactViewCloser.h */,
+				551A71251B8FBC5B0092CE83 /* ReactViewCloser.m */,
 			);
 			path = TestApp;
 			sourceTree = "<group>";
@@ -311,6 +316,7 @@
 				F726FB4721D30522A5DE8F1F /* AppDelegate.m in Sources */,
 				F726F6D69E9D73C121910223 /* ViewController.m in Sources */,
 				F726FD31E6819A00D7AF9ABF /* ReactView.m in Sources */,
+				551A71261B8FBC5B0092CE83 /* ReactViewCloser.m in Sources */,
 				F726FA011522CC3DF6D3CDC1 /* MyReactView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TestApp/ReactView.h
+++ b/TestApp/ReactView.h
@@ -11,7 +11,8 @@
 
 @end
 
-
 @interface ReactView : UIView <ReactViewDelegate>
+
+@property (nonatomic, strong) RCTRootView *rootView;
 
 @end

--- a/TestApp/ReactView.m
+++ b/TestApp/ReactView.m
@@ -3,8 +3,6 @@
 
 @interface ReactView ()
 
-@property (nonatomic, strong) RCTRootView *rootView;
-
 @end
 
 
@@ -13,11 +11,11 @@
 #pragma mark ReactViewDelegate
 
 + (NSString *)jsFileName {
-    return @"";
+    return @"index";
 }
 
 + (NSString *)jsModuleName {
-    return @"";
+    return @"MyReactView";
 }
 
 + (NSString *)javaScriptHost {

--- a/TestApp/ReactViewCloser.h
+++ b/TestApp/ReactViewCloser.h
@@ -1,0 +1,19 @@
+//
+//  ReactViewCloser.h
+//  TestApp
+//
+//  Created by Dave Sibiski on 8/27/15.
+//  Copyright (c) 2015 Bhargav Nookala. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+#import "RCTBridgeModule.h"
+#import "ViewController.h"
+
+@interface ReactViewCloser : NSObject <RCTBridgeModule>
+
+@property (nonatomic, strong) ViewController *viewController;
+
+@end

--- a/TestApp/ReactViewCloser.m
+++ b/TestApp/ReactViewCloser.m
@@ -1,0 +1,24 @@
+//
+//  ReactViewCloser.m
+//  TestApp
+//
+//  Created by Dave Sibiski on 8/27/15.
+//  Copyright (c) 2015 Bhargav Nookala. All rights reserved.
+//
+
+#import "ReactViewCloser.h"
+
+@implementation ReactViewCloser
+
+RCT_EXPORT_MODULE(MyModule);
+
+RCT_EXPORT_METHOD(dismissView){
+    NSLog(@"Hiding the react view via react native control.");
+    [(ViewController *)self.viewController reactView].hidden = YES;
+}
+
+- (dispatch_queue_t)methodQueue {
+    return dispatch_get_main_queue();
+}
+
+@end

--- a/TestApp/ViewController.h
+++ b/TestApp/ViewController.h
@@ -7,12 +7,12 @@
 //
 
 
-#import <UIKit/UIKit.h>\
+#import <UIKit/UIKit.h>
 
-#import "RCTBridgeModule.h"
+#import "ReactView.h"
 
+@interface ViewController : UIViewController
 
-@interface ViewController : UIViewController <RCTBridgeModule>
-
+@property (nonatomic, strong) ReactView *reactView;
 
 @end

--- a/TestApp/ViewController.m
+++ b/TestApp/ViewController.m
@@ -9,11 +9,10 @@
 
 #import "ViewController.h"
 #import "MyReactView.h"
-
+#import "ReactViewCloser.h"
 
 @interface ViewController ()
 
-@property (nonatomic, strong) MyReactView *myReactView;
 @property (nonatomic, strong) UIButton *myButton;
 
 @end
@@ -25,7 +24,7 @@
     [super viewDidLoad];
     // Do any additional setup after loading the view, typically from a nib.
 
-    [self.view addSubview:self.myReactView];
+    [self.view addSubview:self.reactView];
     [self.view addSubview:self.myButton];
 }
 
@@ -35,12 +34,13 @@
 }
 
 
-- (MyReactView *)myReactView {
-    if (_myReactView == nil) {
-        _myReactView = [[MyReactView alloc] initWithFrame:CGRectMake(0, 10, 320, 480)];
+- (ReactView *)reactView {
+    if (_reactView == nil) {
+        _reactView = [[ReactView alloc] initWithFrame:CGRectMake(0, 10, 320, 480)];
+       [(ReactViewCloser *)_reactView.rootView.bridge.modules[@"MyModule"] setViewController:self];
     }
 
-    return _myReactView;
+    return _reactView;
 }
 
 - (UIButton *)myButton {
@@ -56,20 +56,7 @@
 
 - (void)dismissViaNativeControl {
     NSLog(@"Hiding the react view via native IOS control.");
-    self.myReactView.hidden = !self.myReactView.isHidden;
+    self.reactView.hidden = !self.reactView.isHidden;
 }
-
-
-RCT_EXPORT_MODULE(MyModule);
-
-RCT_EXPORT_METHOD(dismissView){
-    NSLog(@"Hiding the react view via react native control.");
-    self.myReactView.hidden = YES;
-}
-
-- (dispatch_queue_t)methodQueue {
-    return dispatch_get_main_queue();
-}
-
 
 @end


### PR DESCRIPTION
This passes the `ViewController` instance to this new native module after the `rootView` has been created.

I definitely had to hack up your implementation, and it's not as clean. But this may give you a good idea of how something like this can be done and perhaps clean it up to work with your setup.

Addresses: https://github.com/facebook/react-native/issues/2453#issuecomment-135523916
